### PR TITLE
Updated HUD, updated Player.tscn to be centered and removed camera offset

### DIFF
--- a/Scenes/HP.gd
+++ b/Scenes/HP.gd
@@ -1,0 +1,13 @@
+extends Label
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	text = "HP: " + str(get_node("../../Player").health)
+
+	

--- a/Scenes/Map.tscn
+++ b/Scenes/Map.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://c7vvamjrpkpwr"]
+[gd_scene load_steps=23 format=3 uid="uid://c7vvamjrpkpwr"]
 
 [ext_resource type="Script" path="res://Scenes/Map.gd" id="1_srjri"]
 [ext_resource type="PackedScene" uid="uid://dg6s6vyhrq1sr" path="res://Scenes/Player.tscn" id="2_64vdv"]
@@ -10,7 +10,9 @@
 [ext_resource type="PackedScene" uid="uid://hlf7g6xk8fjx" path="res://Scenes/Vader.tscn" id="6_prje0"]
 [ext_resource type="Texture2D" uid="uid://bh23piuaee48a" path="res://Art/Tiles/PointLightLightmask.png" id="7_veje6"]
 [ext_resource type="Texture2D" uid="uid://bnvenwbd4vopb" path="res://Art/Tiles/SET1_decorative_obj.png" id="10_1uavh"]
+[ext_resource type="Theme" uid="uid://dvqg3mlr181xd" path="res://Themes/default_theme.tres" id="10_p4fg2"]
 [ext_resource type="Texture2D" uid="uid://b5fvs7oia3g86" path="res://Art/Tiles/SET1_Mainlev_build.png" id="11_d2468"]
+[ext_resource type="Script" path="res://Scenes/HP.gd" id="12_t87p0"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ovqhk"]
 texture = ExtResource("4_qb7c1")
@@ -11305,22 +11307,38 @@ layer_0/tile_data = PackedInt32Array(2228237, 196608, 0, 2228238, 262144, 0, 222
 [node name="Player" parent="Player" instance=ExtResource("2_64vdv")]
 position = Vector2(240, 552)
 
-[node name="TextureButton" type="TextureButton" parent="Player/Player"]
-offset_left = 488.0
-offset_top = -256.0
-offset_right = 616.0
-offset_bottom = -216.0
-texture_normal = ExtResource("4_lb85g")
-texture_pressed = ExtResource("5_34kt8")
-ignore_texture_size = true
-stretch_mode = 6
-
 [node name="PointLight2D" type="PointLight2D" parent="Player/Player"]
 position = Vector2(45, -44)
 color = Color(0.301961, 0.788235, 0.894118, 1)
 energy = 0.5
 texture = ExtResource("7_veje6")
 texture_scale = 20.0
+
+[node name="UI" type="CanvasLayer" parent="Player"]
+
+[node name="HP" type="Label" parent="Player/UI"]
+offset_left = 22.0
+offset_top = 19.0
+offset_right = 135.0
+offset_bottom = 103.0
+theme = ExtResource("10_p4fg2")
+text = "HP: "
+script = ExtResource("12_t87p0")
+
+[node name="TextureButton" type="TextureButton" parent="Player/UI"]
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -300.0
+offset_top = 45.0
+offset_right = -172.0
+offset_bottom = 85.0
+grow_horizontal = 0
+scale = Vector2(2, 2)
+texture_normal = ExtResource("4_lb85g")
+texture_pressed = ExtResource("5_34kt8")
+ignore_texture_size = true
+stretch_mode = 6
 
 [node name="Mobs" type="Node2D" parent="."]
 
@@ -11331,4 +11349,4 @@ position = Vector2(637, 453)
 tile_set = SubResource("TileSet_dodoq")
 format = 2
 
-[connection signal="pressed" from="Player/Player/TextureButton" to="." method="_on_texture_button_pressed"]
+[connection signal="pressed" from="Player/UI/TextureButton" to="." method="_on_texture_button_pressed"]

--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -129,20 +129,21 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2foj3"]
-size = Vector2(18, 48.1875)
+size = Vector2(16, 48.1875)
 
 [node name="Player" type="CharacterBody2D"]
 script = ExtResource("1_xnq8h")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(32.325, -32)
+position = Vector2(0, -32)
 sprite_frames = SubResource("SpriteFrames_uyjo6")
 animation = &"Run"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(31, -23.9063)
+position = Vector2(0, -24)
 shape = SubResource("RectangleShape2D_2foj3")
 
 [node name="Camera2D" type="Camera2D" parent="."]
-offset = Vector2(200, -25)
+position = Vector2(0, -35)
+offset = Vector2(0, -25)
 zoom = Vector2(2, 2)

--- a/Scenes/Vader.gd
+++ b/Scenes/Vader.gd
@@ -1,21 +1,25 @@
 extends CharacterBody2D
-
+# TODO: Add death animation and incorporate video elements at 01:05.
 
 const SPEED = 200.0
 const JUMP_VELOCITY = -400.0
 var player
 var chase = false
+var doDamage = false
 @onready var animated_sprite : AnimatedSprite2D = $AnimatedSprite2D
 
 # Get the gravity from the project settings to be synced with RigidBody nodes.
 var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 
+# Ensure game starts with Idle anim
+func _ready():
+	get_node("AnimatedSprite2D").play("Idle")
 
 func _physics_process(delta):
 	# Add the gravity.
 	if not is_on_floor():
 		velocity.y += gravity * delta
-	animated_sprite.play("Idle")
+	
 	
 	# Detect and attack player
 	if chase == true:
@@ -46,3 +50,16 @@ func _on_player_detection_area_body_exited(body):
 	if body.name == "Player":
 		print("Player Escaped!")
 		chase = false
+		animated_sprite.play("Idle")
+
+func _on_player_damage_area_body_entered(body):
+	if body.name == "Player":
+		doDamage = true
+		while (doDamage):
+			await get_tree().create_timer(0.2).timeout
+			body.health -= 3
+
+
+func _on_player_damage_area_body_exited(body):
+	if body.name == "Player":
+		doDamage = false

--- a/Scenes/Vader.tscn
+++ b/Scenes/Vader.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=16 format=3 uid="uid://hlf7g6xk8fjx"]
+[gd_scene load_steps=17 format=3 uid="uid://hlf7g6xk8fjx"]
 
 [ext_resource type="Texture2D" uid="uid://bia80oc6asj7h" path="res://Art/Sprites/VaderIdle.png" id="1_kqd02"]
 [ext_resource type="Script" path="res://Scenes/Vader.gd" id="1_xlh07"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_7lrkg"]
+radius = 8.0
 height = 54.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_shkmq"]
@@ -87,13 +88,15 @@ animations = [{
 [sub_resource type="CircleShape2D" id="CircleShape2D_fbpuy"]
 radius = 259.278
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_butls"]
+size = Vector2(21, 54)
+
 [node name="Vader" type="CharacterBody2D"]
 script = ExtResource("1_xlh07")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(-1, -28)
+position = Vector2(-3, -28)
 shape = SubResource("CapsuleShape2D_7lrkg")
-metadata/_edit_lock_ = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 position = Vector2(0, -32)
@@ -103,6 +106,7 @@ frame_progress = 0.424277
 metadata/_edit_lock_ = true
 
 [node name="PlayerDetectionArea" type="Area2D" parent="."]
+visible = false
 position = Vector2(0, -36)
 metadata/_edit_lock_ = true
 
@@ -111,5 +115,14 @@ position = Vector2(-1, 9)
 shape = SubResource("CircleShape2D_fbpuy")
 metadata/_edit_lock_ = true
 
+[node name="PlayerDamageArea" type="Area2D" parent="."]
+metadata/_edit_lock_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerDamageArea"]
+position = Vector2(-2.5, -28)
+shape = SubResource("RectangleShape2D_butls")
+
 [connection signal="body_entered" from="PlayerDetectionArea" to="." method="_on_player_detection_area_body_entered"]
 [connection signal="body_exited" from="PlayerDetectionArea" to="." method="_on_player_detection_area_body_exited"]
+[connection signal="body_entered" from="PlayerDamageArea" to="." method="_on_player_damage_area_body_entered"]
+[connection signal="body_exited" from="PlayerDamageArea" to="." method="_on_player_damage_area_body_exited"]

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -3,8 +3,8 @@ extends CharacterBody2D
 
 const SPEED = 300.0
 const JUMP_VELOCITY = -400.0
-const gravity = 1200
-var health = 10
+const gravity = 1000
+var health = 100
 var damage = 1
 var isDead = false
 
@@ -40,14 +40,11 @@ func _physics_process(delta):
 		velocity.x = move_toward(velocity.x, 0, SPEED)
 		if velocity.y == 0:
 			animated_sprite.play("Idle")
-
+	
 	move_and_slide()
 	
-
-func take_damage(damage_taken):
-	if health > 0:
-		health -= damage_taken
-		print(health)
-	if health <= 0:
-		isDead = true
-		print(isDead)
+	if health < 0:
+		print("Player died!")
+		queue_free()
+		get_tree().change_scene_to_file("res://Scenes/Menu.tscn")
+	


### PR DESCRIPTION
HUD elements are now attached to a Canvas Layer which follows the player. Player is now centered to fix the issue where Vader was confused about which direction to move. The Player camera offset is also reset to 0. The offset was only intended for a single directional side-scroller and is no longer necessary. 